### PR TITLE
Add delay logic between droplet download retries

### DIFF
--- a/downloader.go
+++ b/downloader.go
@@ -16,10 +16,10 @@ import (
 )
 
 const (
-	MAX_DOWNLOAD_ATTEMPTS = 4
+	MAX_DOWNLOAD_ATTEMPTS = 3
 	IDLE_TIMEOUT          = 10 * time.Second
-	RETRY_WAIT_MIN        = 200 * time.Millisecond
-	RETRY_WAIT_MAX        = 20 * time.Second
+	RETRY_WAIT_MIN        = 500 * time.Millisecond
+	RETRY_WAIT_MAX        = 5 * time.Second
 	NoBytesReceived       = -1
 )
 
@@ -102,7 +102,7 @@ func NewDownloaderWithIdleTimeout(requestTimeout time.Duration, idleTimeout time
 				tc.SetKeepAlive(true)
 				tc.SetKeepAlivePeriod(30 * time.Second)
 			}
-			return &idleTimeoutConn{IDLE_TIMEOUT, c}, nil
+			return &idleTimeoutConn{idleTimeout, c}, nil
 		},
 		TLSHandshakeTimeout: 10 * time.Second,
 		TLSClientConfig:     tlsConfig,

--- a/downloader.go
+++ b/downloader.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"math/rand"
 	"net"
 	"net/http"
 	"net/url"
@@ -20,16 +21,22 @@ const (
 	IDLE_TIMEOUT          = 10 * time.Second
 	RETRY_WAIT_MIN        = 500 * time.Millisecond
 	RETRY_WAIT_MAX        = 5 * time.Second
+	MAX_JITTER            = 200 * time.Millisecond
 	NoBytesReceived       = -1
 )
 
-func Backoff(min, max time.Duration, attemptNum int) time.Duration {
-	mult := math.Pow(2, float64(attemptNum)) * float64(min)
+func backoff(minRetry, maxRetry, maxJitter time.Duration, attemptNum int) time.Duration {
+	mult := math.Pow(2, float64(attemptNum)) * float64(minRetry)
 	sleep := time.Duration(mult)
-	if float64(sleep) != mult || sleep > max {
-		sleep = max
+	if float64(sleep) != mult || sleep > maxRetry {
+		sleep = maxRetry
 	}
-	return sleep
+	return sleep + jitter()
+}
+
+func jitter() time.Duration {
+	rand.Seed(time.Now().UnixNano())
+	return ((MAX_JITTER / 100) * time.Duration(rand.Intn(100)))
 }
 
 type DownloadCancelledError struct {
@@ -154,7 +161,7 @@ func (downloader *Downloader) Download(
 		if _, ok := err.(*ChecksumFailedError); ok {
 			break
 		}
-		time.Sleep(Backoff(RETRY_WAIT_MIN, RETRY_WAIT_MAX, attempt))
+		time.Sleep(backoff(RETRY_WAIT_MIN, RETRY_WAIT_MAX, MAX_JITTER, attempt))
 	}
 
 	if err != nil {

--- a/downloader.go
+++ b/downloader.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	MAX_DOWNLOAD_ATTEMPTS = 3
+	MAX_DOWNLOAD_ATTEMPTS = 4
 	IDLE_TIMEOUT          = 10 * time.Second
 	RETRY_WAIT_MIN        = 500 * time.Millisecond
 	RETRY_WAIT_MAX        = 5 * time.Second

--- a/downloader.go
+++ b/downloader.go
@@ -16,10 +16,10 @@ import (
 )
 
 const (
-	MAX_DOWNLOAD_ATTEMPTS = 5
+	MAX_DOWNLOAD_ATTEMPTS = 4
 	IDLE_TIMEOUT          = 10 * time.Second
-	RETRY_WAIT_MIN        = 500 * time.Millisecond
-	RETRY_WAIT_MAX        = 16 * time.Second
+	RETRY_WAIT_MIN        = 200 * time.Millisecond
+	RETRY_WAIT_MAX        = 20 * time.Second
 	NoBytesReceived       = -1
 )
 

--- a/downloader.go
+++ b/downloader.go
@@ -179,18 +179,17 @@ func (downloader *Downloader) fetchToFile(
 	if err != nil {
 		return "", CachingInfoType{}, err
 	}
-
-	ctx, cancel := context.WithCancel(req.Context())
-	defer cancel()
-
-	req = req.WithContext(ctx)
-
 	if cachingInfoIn.ETag != "" {
 		req.Header.Add("If-None-Match", cachingInfoIn.ETag)
 	}
 	if cachingInfoIn.LastModified != "" {
 		req.Header.Add("If-Modified-Since", cachingInfoIn.LastModified)
 	}
+
+	ctx, cancel := context.WithCancel(req.Context())
+	defer cancel()
+
+	req = req.WithContext(ctx)
 
 	completeChan := make(chan struct{})
 	defer close(completeChan)

--- a/downloader.go
+++ b/downloader.go
@@ -25,18 +25,18 @@ const (
 	NoBytesReceived       = -1
 )
 
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
 func backoff(minRetry, maxRetry, maxJitter time.Duration, attemptNum int) time.Duration {
 	mult := math.Pow(2, float64(attemptNum)) * float64(minRetry)
 	sleep := time.Duration(mult)
 	if float64(sleep) != mult || sleep > maxRetry {
 		sleep = maxRetry
 	}
-	return sleep + jitter()
-}
-
-func jitter() time.Duration {
-	rand.Seed(time.Now().UnixNano())
-	return ((MAX_JITTER / 100) * time.Duration(rand.Intn(100)))
+	jitter := (MAX_JITTER / 100) * time.Duration(rand.Intn(100))
+	return sleep + jitter
 }
 
 type DownloadCancelledError struct {

--- a/downloader_test.go
+++ b/downloader_test.go
@@ -192,7 +192,7 @@ var _ = Describe("Downloader", func() {
 				serverUrl, _ = url.Parse(testServer.URL + "/somepath")
 			})
 
-			It("should retry 3 times and return an error", func() {
+			It("should retry cacheddownloader.MAX_DOWNLOAD_ATTEMPTS times and return an error", func() {
 				errs := make(chan error)
 				downloadedFiles := make(chan string)
 
@@ -203,7 +203,7 @@ var _ = Describe("Downloader", func() {
 				}()
 
 				for i := 0; i < cacheddownloader.MAX_DOWNLOAD_ATTEMPTS; i++ {
-					Eventually(requestInitiated, 2*time.Second).Should(Receive())
+					Eventually(requestInitiated, 5*time.Second).Should(Receive())
 				}
 
 				Expect(<-errs).To(HaveOccurred())

--- a/downloader_test.go
+++ b/downloader_test.go
@@ -202,9 +202,9 @@ var _ = Describe("Downloader", func() {
 					downloadedFiles <- downloadedFile
 				}()
 
-				Eventually(requestInitiated).Should(Receive())
-				Eventually(requestInitiated).Should(Receive())
-				Eventually(requestInitiated).Should(Receive())
+				for i := 0; i < cacheddownloader.MAX_DOWNLOAD_ATTEMPTS; i++ {
+					Eventually(requestInitiated, 2*time.Second).Should(Receive())
+				}
 
 				Expect(<-errs).To(HaveOccurred())
 				Expect(<-downloadedFiles).To(BeEmpty())
@@ -266,7 +266,7 @@ var _ = Describe("Downloader", func() {
 				}()
 
 				var err error
-				Eventually(errs).Should(Receive(&err))
+				Eventually(errs, 2*time.Second).Should(Receive(&err))
 				uErr, ok := err.(*url.Error)
 				Expect(ok).To(BeTrue())
 				opErr, ok := uErr.Err.(*net.OpError)

--- a/downloader_test.go
+++ b/downloader_test.go
@@ -266,7 +266,7 @@ var _ = Describe("Downloader", func() {
 				}()
 
 				var err error
-				Eventually(errs, 4*time.Second).Should(Receive(&err))
+				Eventually(errs, 1*time.Minute).Should(Receive(&err))
 				uErr, ok := err.(*url.Error)
 				Expect(ok).To(BeTrue())
 				opErr, ok := uErr.Err.(*net.OpError)

--- a/downloader_test.go
+++ b/downloader_test.go
@@ -266,7 +266,7 @@ var _ = Describe("Downloader", func() {
 				}()
 
 				var err error
-				Eventually(errs, 2*time.Second).Should(Receive(&err))
+				Eventually(errs, 4*time.Second).Should(Receive(&err))
 				uErr, ok := err.(*url.Error)
 				Expect(ok).To(BeTrue())
 				opErr, ok := uErr.Err.(*net.OpError)

--- a/downloader_test.go
+++ b/downloader_test.go
@@ -242,7 +242,7 @@ var _ = Describe("Downloader", func() {
 			var done chan struct{}
 
 			BeforeEach(func() {
-				done = make(chan struct{}, 3)
+				done = make(chan struct{}, cacheddownloader.MAX_DOWNLOAD_ATTEMPTS)
 				downloader = cacheddownloader.NewDownloaderWithIdleTimeout(1*time.Second, 30*time.Millisecond, 10, nil)
 
 				testServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -254,7 +254,7 @@ var _ = Describe("Downloader", func() {
 			})
 
 			AfterEach(func() {
-				Eventually(done).Should(HaveLen(3))
+				Eventually(done).Should(HaveLen(cacheddownloader.MAX_DOWNLOAD_ATTEMPTS))
 			})
 
 			It("fails with a nested read error", func() {

--- a/downloader_test.go
+++ b/downloader_test.go
@@ -3,9 +3,9 @@ package cacheddownloader_test
 import (
 	"bytes"
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -18,6 +18,7 @@ import (
 	"code.cloudfoundry.org/lager/lagertest"
 	"code.cloudfoundry.org/systemcerts"
 	"code.cloudfoundry.org/tlsconfig"
+	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/ghttp"
 
 	. "github.com/onsi/ginkgo"
@@ -46,8 +47,7 @@ var _ = Describe("Downloader", func() {
 	BeforeEach(func() {
 		logger = lagertest.NewTestLogger("test")
 		testServer = nil
-		client := cacheddownloader.NewHTTPClient(1, 1*time.Second, 10*time.Millisecond, 500*time.Millisecond, 1*time.Second, nil)
-		downloader = cacheddownloader.NewDownloaderWithIdleTimeout(client, 10)
+		downloader = cacheddownloader.NewDownloader(downloadTimeout, 10, nil)
 		lock = &sync.Mutex{}
 		cancelChan = make(chan struct{}, 0)
 	})
@@ -203,7 +203,9 @@ var _ = Describe("Downloader", func() {
 				}()
 
 				Eventually(requestInitiated).Should(Receive())
-				testServer.Close()
+				Eventually(requestInitiated).Should(Receive())
+				Eventually(requestInitiated).Should(Receive())
+
 				Expect(<-errs).To(HaveOccurred())
 				Expect(<-downloadedFiles).To(BeEmpty())
 			})
@@ -237,25 +239,39 @@ var _ = Describe("Downloader", func() {
 		})
 
 		Context("when the read exceeds the deadline timeout", func() {
+			var done chan struct{}
 
 			BeforeEach(func() {
-				client := cacheddownloader.NewHTTPClient(1, 1*time.Second, 10*time.Millisecond, 500*time.Millisecond, 1*time.Second, nil)
-				downloader = cacheddownloader.NewDownloaderWithIdleTimeout(client, 10)
+				done = make(chan struct{}, 3)
+				downloader = cacheddownloader.NewDownloaderWithIdleTimeout(1*time.Second, 30*time.Millisecond, 10, nil)
 
 				testServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					time.Sleep(100 * time.Millisecond)
+					done <- struct{}{}
 				}))
 
 				serverUrl, _ = url.Parse(testServer.URL + "/somepath")
 			})
 
-			It("fails with a read error", func() {
+			AfterEach(func() {
+				Eventually(done).Should(HaveLen(3))
+			})
 
-				_, _, err := downloader.Download(logger, serverUrl, createDestFile, cacheddownloader.CachingInfoType{}, cacheddownloader.ChecksumInfoType{}, cancelChan)
-				unWrappedError := errors.Unwrap(err)
-				uErr, ok := unWrappedError.(*url.Error)
+			It("fails with a nested read error", func() {
+				errs := make(chan error)
+
+				go func() {
+					_, _, err := downloader.Download(logger, serverUrl, createDestFile, cacheddownloader.CachingInfoType{}, cacheddownloader.ChecksumInfoType{}, cancelChan)
+					errs <- err
+				}()
+
+				var err error
+				Eventually(errs).Should(Receive(&err))
+				uErr, ok := err.(*url.Error)
 				Expect(ok).To(BeTrue())
-				Expect(uErr.Err.Error()).To(ContainSubstring("read"))
+				opErr, ok := uErr.Err.(*net.OpError)
+				Expect(ok).To(BeTrue())
+				Expect(opErr.Op).To(Equal("read"))
 			})
 		})
 
@@ -296,10 +312,13 @@ var _ = Describe("Downloader", func() {
 					case <-time.After(30 * time.Second):
 						return
 					}
-					w.Write(bytes.Repeat([]byte("a"), 1024))
+					for i := 0; i < 100000; i++ {
+						w.Write(bytes.Repeat([]byte("a"), 1024))
+					}
 					w.(http.Flusher).Flush()
 					select {
 					case <-completeRequest:
+						return
 					case <-time.After(30 * time.Second):
 						return
 					}
@@ -310,22 +329,31 @@ var _ = Describe("Downloader", func() {
 
 			It("cancels the request and returns the error", func() {
 				errs := make(chan error)
-				client := cacheddownloader.NewHTTPClient(1, 1*time.Second, 10*time.Millisecond, 500*time.Millisecond, 1*time.Second, nil)
-				downloader = cacheddownloader.NewDownloaderWithIdleTimeout(client, 10)
+
 				go func() {
 					_, _, err := downloader.Download(logger, serverUrl, createDestFile, cacheddownloader.CachingInfoType{}, cacheddownloader.ChecksumInfoType{}, cancelChan)
 					errs <- err
-					Eventually(errs).Should(Receive(SatisfyAll(
-						BeAssignableToTypeOf(&cacheddownloader.DownloadCancelledError{}),
-						MatchError(MatchRegexp(`Download cancelled: source 'fetch-request', duration .*, Error: .*`)),
-					)))
-
-					close(completeRequest)
 				}()
+
+				Eventually(requestInitiated).Should(Receive())
+				close(cancelChan)
+
+				Eventually(errs).Should(Receive(SatisfyAll(
+					BeAssignableToTypeOf(&cacheddownloader.DownloadCancelledError{}),
+					MatchError(MatchRegexp(`Download cancelled: source 'fetch-request', duration .*, Error: .*`)),
+				)))
+
+				close(completeRequest)
 			})
 
 			It("stops the download", func() {
 				errs := make(chan error)
+				destFile, err := ioutil.TempFile("", "foo")
+				Expect(err).NotTo(HaveOccurred())
+
+				createDestFile := func() (*os.File, error) {
+					return destFile, nil
+				}
 
 				go func() {
 					_, _, err := downloader.Download(logger, serverUrl, createDestFile, cacheddownloader.CachingInfoType{}, cacheddownloader.ChecksumInfoType{}, cancelChan)
@@ -334,10 +362,18 @@ var _ = Describe("Downloader", func() {
 
 				Eventually(requestInitiated).Should(Receive())
 				completeRequest <- struct{}{}
+
+				// Make sure download started to local file
+				Eventually(func() int {
+					fi, err := os.Stat(destFile.Name())
+					Expect(err).NotTo(HaveOccurred())
+					return int(fi.Size())
+				}).Should(BeNumerically(">", 10))
 				close(cancelChan)
 
 				Eventually(errs).Should(Receive(BeAssignableToTypeOf(&cacheddownloader.DownloadCancelledError{})))
 				close(completeRequest)
+				Consistently(logger).ShouldNot(gbytes.Say(`bytes-written":102400000`))
 			})
 		})
 
@@ -595,8 +631,7 @@ var _ = Describe("Downloader", func() {
 			barrier = make(chan interface{}, 1)
 			results = make(chan bool, 1)
 
-			client := cacheddownloader.NewHTTPClient(1, 1*time.Second, 10*time.Second, 500*time.Millisecond, 20*time.Second, nil)
-			downloader = cacheddownloader.NewDownloader(1*time.Second, 1, nil, client)
+			downloader = cacheddownloader.NewDownloader(1*time.Second, 1, nil)
 
 			var err error
 			tempDir, err = ioutil.TempDir("", "temp-dl-dir")


### PR DESCRIPTION
This PR extends https://github.com/cloudfoundry/cacheddownloader/pull/18 

- Fixes a retry test that failed in CI
- Adds a random jitter duration between retries to avoid synchronised requests 
