### PR TITLE
Add "Retrying" and "failed" log messages

### DIFF
--- a/downloader.go
+++ b/downloader.go
@@ -161,10 +161,12 @@ func (downloader *Downloader) Download(
 		if _, ok := err.(*ChecksumFailedError); ok {
 			break
 		}
+		logger.Info("retrying", lager.Data{"attempt": attempt})
 		time.Sleep(backoff(RETRY_WAIT_MIN, RETRY_WAIT_MAX, MAX_JITTER, attempt))
 	}
 
 	if err != nil {
+		logger.Error("download-failed", err)
 		return "", CachingInfoType{}, err
 	}
 


### PR DESCRIPTION
### What is this change about?

Some time ago we introduced retying for the cacheddowloader (https://github.com/cloudfoundry/cacheddownloader/pull/18)
This change is about adding 2 additional logs, to allow planning actions if landscape needs to be scaled down due to rate-limits

### What problem it is trying to solve?

Currently, for sake of simplicity, the code just hardcodes the retry configuration as 4 retries, with up to max 5s of timeout. While our tests have shown that this will most likely be enough, it would be good to have some additional data - how many attempts were done to download the blob, and a dump if the download fails. 

### What is the impact if the change is not made?

Having those logs likes will allow to create monitors that count those logs and raise alerts in case download errors start to happen. As a mitigation, the number of rep/max_concurrent_downloads can be scaled down afterwards.

### How should this change be described in diego-release release notes?

Add logs when cachedownloader retries or fails a droplet download

### Please provide any contextual information.

https://github.com/cloudfoundry/cacheddownloader/pull/18

### Tag your pair, your PM, and/or team!
@geofffranks 

Thank you!
