### PR TITLE
Increase cachedownloader retry interval

### DIFF
--- a/downloader.go
+++ b/downloader.go
@@ -17,9 +17,9 @@ import (
 )
 
 const (
-	MAX_DOWNLOAD_ATTEMPTS = 4
+	MAX_DOWNLOAD_ATTEMPTS = 6
 	IDLE_TIMEOUT          = 10 * time.Second
-	RETRY_WAIT_MIN        = 500 * time.Millisecond
+	RETRY_WAIT_MIN        = 1000 * time.Millisecond
 	RETRY_WAIT_MAX        = 5 * time.Second
 	MAX_JITTER            = 200 * time.Millisecond
 	NoBytesReceived       = -1


### PR DESCRIPTION
### What is this change about?

This change is about tweaking the retry interval of the cachedownloader. As we introduced it few months ago [here](https://github.com/cloudfoundry/diego-release/issues/628). We were not sure what would be the best default retry strategy. So we put 4 retries with 0.5 seconds initial retry, which results in retrying after 0.5s, 1, 2, So in total 4 retries in 3.5 seconds.

After further evaluating the results in the last months, we discovered that while this mitigates some problems, some blobstores, like Azure need more time to reset the throttling limits. Therefore our proposal is to change the defaults to 6 retries starting with 1 second of initial delay. This would result in the following retry delays [1, 2, 4, 5, 5] (due to the 5 sec max delay), which equals to 17 seconds max delay.

Our assumption is that that this configuration will ensure that working with Azure is resilient even with the default blobstore throttling limits and default cachedownloader configuration.

Should it turn out that further tweaking is necessary, then the proposal would be to spend more effort and make this configurable. 

### What problem it is trying to solve?

Make the cacheddowloader resilient to blobstore throttling limits.

### What is the impact if the change is not made?

Ops teams need to ask Blobstore providers to increase threshold limits, decrease maximum number of concurrent downloads, decrease bosh max-in-flight number

### How should this change be described in diego-release release notes?

Increase the default retries of for dowloading droplets from 4 to 6 times.

### Please provide any contextual information.

https://github.com/cloudfoundry/diego-release/issues/628

### Tag your pair, your PM, and/or team!

@PlamenDoychev 

Thank you!
