### PR TITLE
Revert "Increase retry interval (#22)"

### DIFF
--- a/downloader.go
+++ b/downloader.go
@@ -17,9 +17,9 @@ import (
 )
 
 const (
-	MAX_DOWNLOAD_ATTEMPTS = 6
+	MAX_DOWNLOAD_ATTEMPTS = 4
 	IDLE_TIMEOUT          = 10 * time.Second
-	RETRY_WAIT_MIN        = 1000 * time.Millisecond
+	RETRY_WAIT_MIN        = 500 * time.Millisecond
 	RETRY_WAIT_MAX        = 5 * time.Second
 	MAX_JITTER            = 200 * time.Millisecond
 	NoBytesReceived       = -1


### PR DESCRIPTION
This reverts commit 601773e3c0182d1f3794bc4274628652398aad95.

This caused failures in our windows and linux tests with no backing store (e.g. `mysql` or `postgres`). I'm reverting this to clean up the pipeline.