### PR TITLE
Test new CachedDownloader fails to create temp dir

### DIFF
--- a/cached_downloader_test.go
+++ b/cached_downloader_test.go
@@ -85,6 +85,17 @@ var _ = Describe("File cache", func() {
 		os.RemoveAll(uncachedPath)
 	})
 
+	Describe("When a new CachedDownloader fails to create a temp directory for the cache", func() {
+		It("returns an error", func() {
+			cachedPath = ""
+			cache = cacheddownloader.NewCache(cachedPath, maxSizeInBytes)
+			downloader = cacheddownloader.NewDownloader(1*time.Second, MAX_CONCURRENT_DOWNLOADS, nil)
+			cachedDownloader, err = cacheddownloader.New(downloader, cache, transformer)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("could not create cache path"))
+		})
+	})
+
 	Describe("when the cache folder does not exist", func() {
 		It("should create it", func() {
 			os.RemoveAll(cachedPath)


### PR DESCRIPTION
- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
- Handle error in https://vmw-jira.broadcom.net/browse/TPCF-27313
  - Test when a new CachedDownloader fails to create a temporary directory
  - Cannot reliably and consistently test when a new CachedDownloader fails to remove a preexisting temporary cache directory
  - `CachedDownloader.New` is called in `executor`, which has a test on failure to create a temporary directory [here](https://github.com/cloudfoundry/executor/pull/107)

Backward Compatibility
---------------
Breaking Change? **No**
