### PR TITLE
fix: extend makeRoom() to evict on real partition pressure

### DIFF
--- a/cached_downloader_test.go
+++ b/cached_downloader_test.go
@@ -69,7 +69,7 @@ var _ = Describe("File cache", func() {
 
 		transformer = cacheddownloader.NoopTransform
 
-		cache = cacheddownloader.NewCache(cachedPath, maxSizeInBytes)
+		cache = cacheddownloader.NewCache(cachedPath, maxSizeInBytes, 0)
 		downloader = cacheddownloader.NewDownloader(1*time.Second, MAX_CONCURRENT_DOWNLOADS, nil)
 		cachedDownloader, err = cacheddownloader.New(downloader, cache, transformer)
 		Expect(err).NotTo(HaveOccurred())
@@ -89,7 +89,7 @@ var _ = Describe("File cache", func() {
 	Describe("When a new CachedDownloader fails to create a temp directory for the cache", func() {
 		It("returns an error", func() {
 			cachedPath = ""
-			cache = cacheddownloader.NewCache(cachedPath, maxSizeInBytes)
+			cache = cacheddownloader.NewCache(cachedPath, maxSizeInBytes, 0)
 			downloader = cacheddownloader.NewDownloader(1*time.Second, MAX_CONCURRENT_DOWNLOADS, nil)
 			cachedDownloader, err = cacheddownloader.New(downloader, cache, transformer)
 			Expect(err).To(HaveOccurred())
@@ -1048,7 +1048,7 @@ var _ = Describe("File cache", func() {
 					ghttp.RespondWith(http.StatusOK, string(downloadContent), returnedHeader),
 				))
 
-				cache = cacheddownloader.NewCache(cachedPath, maxSizeInBytes)
+				cache = cacheddownloader.NewCache(cachedPath, maxSizeInBytes, 0)
 				cachedDownloader, err = cacheddownloader.New(downloader, cache, cacheddownloader.TarTransform)
 				Expect(err).ToNot(HaveOccurred())
 
@@ -1321,7 +1321,7 @@ var _ = Describe("File cache", func() {
 				Expect(cachedDownloader.SaveState(logger)).To(Succeed())
 
 				maxSizeInBytes = 32
-				cache = cacheddownloader.NewCache(cachedPath, maxSizeInBytes)
+				cache = cacheddownloader.NewCache(cachedPath, maxSizeInBytes, 0)
 			})
 
 			It("should evict old entries from the cache", func() {

--- a/file_cache.go
+++ b/file_cache.go
@@ -4,9 +4,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"sync"
+	"syscall"
 	"time"
 
 	"code.cloudfoundry.org/archiver/compressor"
@@ -23,11 +25,21 @@ var (
 )
 
 type FileCache struct {
-	CachedPath     string
-	maxSizeInBytes int64
-	Entries        map[string]*FileCacheEntry
-	OldEntries     map[string]*FileCacheEntry
-	Seq            uint64
+	CachedPath                string
+	maxSizeInBytes            int64
+	minimumPartitionFreeBytes int64
+	FreeSpaceFunc             func(path string) int64 `json:"-"`
+	Entries                   map[string]*FileCacheEntry
+	OldEntries                map[string]*FileCacheEntry
+	Seq                       uint64
+}
+
+func defaultFreeSpaceOnPartition(path string) int64 {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(path, &stat); err != nil {
+		return math.MaxInt64
+	}
+	return int64(stat.Bavail) * int64(stat.Bsize)
 }
 
 type FileCacheEntry struct {
@@ -40,13 +52,15 @@ type FileCacheEntry struct {
 	fileInUseCount        int
 }
 
-func NewCache(dir string, maxSizeInBytes int64) *FileCache {
+func NewCache(dir string, maxSizeInBytes, minimumPartitionFreeBytes int64) *FileCache {
 	return &FileCache{
-		CachedPath:     dir,
-		maxSizeInBytes: maxSizeInBytes,
-		Entries:        map[string]*FileCacheEntry{},
-		OldEntries:     map[string]*FileCacheEntry{},
-		Seq:            0,
+		CachedPath:                dir,
+		maxSizeInBytes:            maxSizeInBytes,
+		minimumPartitionFreeBytes: minimumPartitionFreeBytes,
+		FreeSpaceFunc:             defaultFreeSpaceOnPartition,
+		Entries:                   map[string]*FileCacheEntry{},
+		OldEntries:                map[string]*FileCacheEntry{},
+		Seq:                       0,
 	}
 }
 
@@ -378,7 +392,7 @@ func (c *FileCache) updateOldEntries(logger lager.Logger, cacheKey string, entry
 
 func (c *FileCache) makeRoom(logger lager.Logger, size int64, excludedCacheKey string) {
 	usedSpace := c.usedSpace(logger)
-	for c.maxSizeInBytes < usedSpace+size {
+	for c.maxSizeInBytes < usedSpace+size || (c.minimumPartitionFreeBytes > 0 && c.FreeSpaceFunc(c.CachedPath) < c.minimumPartitionFreeBytes) {
 		var oldestEntry *FileCacheEntry
 		oldestAccessTime, oldestCacheKey := maxTime(), ""
 		for ck, f := range c.Entries {

--- a/file_cache_test.go
+++ b/file_cache_test.go
@@ -33,7 +33,7 @@ var _ = Describe("FileCache", func() {
 
 		maxSizeInBytes = 123424
 
-		cache = cacheddownloader.NewCache(cacheDir, maxSizeInBytes)
+		cache = cacheddownloader.NewCache(cacheDir, maxSizeInBytes, 0)
 	})
 
 	AfterEach(func() {
@@ -516,7 +516,7 @@ var _ = Describe("FileCache", func() {
 			Context("when there is not enough space in the cache", func() {
 				BeforeEach(func() {
 					maxSizeInBytes = 150
-					cache = cacheddownloader.NewCache(cacheDir, maxSizeInBytes)
+					cache = cacheddownloader.NewCache(cacheDir, maxSizeInBytes, 0)
 				})
 
 				JustBeforeEach(func() {
@@ -773,7 +773,7 @@ var _ = Describe("FileCache", func() {
 			Context("when there isn't enough space", func() {
 				BeforeEach(func() {
 					maxSizeInBytes = 10
-					cache = cacheddownloader.NewCache(cacheDir, maxSizeInBytes)
+					cache = cacheddownloader.NewCache(cacheDir, maxSizeInBytes, 0)
 				})
 
 				JustBeforeEach(func() {
@@ -832,6 +832,67 @@ var _ = Describe("FileCache", func() {
 			It("closes first the old, then the new", func() {
 				Expect(cache.CloseDirectory(logger, cacheKey, dir1)).To(Succeed())
 				Expect(cache.CloseDirectory(logger, cacheKey, dir2)).To(Succeed())
+			})
+		})
+	})
+
+	Describe("makeRoom partition free-space eviction", func() {
+		var (
+			cacheKey  string
+			cacheInfo cacheddownloader.CachingInfoType
+		)
+
+		BeforeEach(func() {
+			cacheKey = "key"
+			cacheInfo = cacheddownloader.CachingInfoType{}
+			// large in-memory ceiling so only partition pressure triggers eviction
+			maxSizeInBytes = 10 * 1024 * 1024 * 1024
+			cache = cacheddownloader.NewCache(cacheDir, maxSizeInBytes, 5*1024*1024*1024)
+		})
+
+		Context("when partition free space is below the minimum", func() {
+			BeforeEach(func() {
+				cache.FreeSpaceFunc = func(string) int64 { return 0 }
+			})
+
+			It("evicts non-in-use entries even though in-memory ceiling is not exceeded", func() {
+				f1 := createFile("cache-file-1", "content-1")
+				defer os.RemoveAll(f1.Name())
+				rc, err := cache.Add(logger, cacheKey, f1.Name(), 100, cacheInfo)
+				Expect(err).NotTo(HaveOccurred())
+				rc.Close()
+
+				f2 := createFile("cache-file-2", "content-2")
+				defer os.RemoveAll(f2.Name())
+				rc2, err := cache.Add(logger, "key2", f2.Name(), 100, cacheInfo)
+				Expect(err).NotTo(HaveOccurred())
+				rc2.Close()
+
+				_, _, err = cache.Get(logger, cacheKey)
+				Expect(err).To(Equal(cacheddownloader.EntryNotFound))
+			})
+		})
+
+		Context("when partition free space exceeds the minimum", func() {
+			BeforeEach(func() {
+				cache.FreeSpaceFunc = func(string) int64 { return 10 * 1024 * 1024 * 1024 }
+			})
+
+			It("does not evict entries solely due to partition pressure", func() {
+				f1 := createFile("cache-file-1", "content-1")
+				defer os.RemoveAll(f1.Name())
+				rc, err := cache.Add(logger, cacheKey, f1.Name(), 100, cacheInfo)
+				Expect(err).NotTo(HaveOccurred())
+				rc.Close()
+
+				f2 := createFile("cache-file-2", "content-2")
+				defer os.RemoveAll(f2.Name())
+				rc2, err := cache.Add(logger, "key2", f2.Name(), 100, cacheInfo)
+				Expect(err).NotTo(HaveOccurred())
+				rc2.Close()
+
+				_, _, err = cache.Get(logger, cacheKey)
+				Expect(err).NotTo(HaveOccurred())
 			})
 		})
 	})

--- a/integration_test.go
+++ b/integration_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Integration", func() {
 		url, err = url.Parse(server.URL + "/file")
 		Expect(err).NotTo(HaveOccurred())
 
-		cache = cacheddownloader.NewCache(cachedPath, cacheMaxSizeInBytes)
+		cache = cacheddownloader.NewCache(cachedPath, cacheMaxSizeInBytes, 0)
 		downloader = cacheddownloader.NewDownloader(downloadTimeout, 10, nil)
 		cachedDownloader, err = cacheddownloader.New(downloader, cache, cacheddownloader.NoopTransform)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Add minimumPartitionFreeBytes field and FreeSpaceFunc hook to FileCache. makeRoom() now loops until both the in-memory ceiling AND the partition free-space threshold are satisfied, so the download cache cannot silently grow past its reservation when the in-memory size tracker drifts from on-disk reality.

- NewCache gains a third argument: minimumPartitionFreeBytes int64. Pass 0 to disable the partition check (all existing test call sites).
- defaultFreeSpaceOnPartition calls syscall.Statfs; fails open (returns MaxInt64) so a Statfs error never causes spurious eviction.
- FreeSpaceFunc tagged json:"-" so SaveState/RecoverState round-trips are unaffected.

Fixes: TNZ-111552

- [ ] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
<!---
- Briefly explain why this PR is necessary
- Provide details of where this request is coming from including links, GitHub Issues, etc..
- Provide details of prior work (if applicable) including links to commits, github issues, etc...
--->


Backward Compatibility
---------------
Breaking Change? **Yes/No**
<!---
If this is a breaking change, or modifies currently expected behaviors of core functionality

- Has the change been mitigated to be backwards compatible?
- Should this feature be considered experimental for a period of time, and allow operators to opt-in?
- Should this apply immediately to all deployments?
-->
